### PR TITLE
* Removed redundant code

### DIFF
--- a/Part38-Spring Security 6 Validating JWT Token/src/main/java/com/telusko/part29springsecex/config/JwtFilter.java
+++ b/Part38-Spring Security 6 Validating JWT Token/src/main/java/com/telusko/part29springsecex/config/JwtFilter.java
@@ -39,7 +39,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = context.getBean(MyUserDetailsService.class).loadUserByUsername(username);
-            if (jwtService.validateToken(token, userDetails)) {
+            if (jwtService.isTokenExpired(token)) {
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 authToken.setDetails(new WebAuthenticationDetailsSource()
                         .buildDetails(request));

--- a/Part38-Spring Security 6 Validating JWT Token/src/main/java/com/telusko/part29springsecex/service/JWTService.java
+++ b/Part38-Spring Security 6 Validating JWT Token/src/main/java/com/telusko/part29springsecex/service/JWTService.java
@@ -70,12 +70,21 @@ public class JWTService {
                 .getPayload();
     }
 
+    /*
+
+    This `userName.equals(userDetails.getUsername()` is redundant because,
+
+    * Will always result in true
+    * The username is retrieved from the token in the JwtFilter
+    * The UserDetails argument is initialised in the JwtFilter by passing the same username retrieved from the received bearer token
+
+     */
     public boolean validateToken(String token, UserDetails userDetails) {
         final String userName = extractUserName(token);
         return (userName.equals(userDetails.getUsername()) && !isTokenExpired(token));
     }
 
-    private boolean isTokenExpired(String token) {
+    public boolean isTokenExpired(String token) {
         return extractExpiration(token).before(new Date());
     }
 


### PR DESCRIPTION
* Replaced jwtService.validateToken(token, userDetails) call with jwtService.isTokenExpired(token)

Description

    This `userName.equals(userDetails.getUsername()` is redundant because,

    * Will always result in true
    * The username is retrieved from the token in the JwtFilter
    * The UserDetails argument is initialised in the JwtFilter by passing the same username retrieved from the received bearer token

